### PR TITLE
Add package.json for MIP compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "urls": [
+    ["miflora.py", "github:matthias-bs/MicroPython-MiFlora/miflora.py"],
+    ["ble_advertising.py", "github:matthias-bs/MicroPython-MiFlora/ble_advertising.py"]
+  ],
+  "version": "1.0.0",
+  "deps": []
+}


### PR DESCRIPTION
This PR adds a package.json file to make the library compatible with the MicroPython Package Manager (MIP).

With this change, users can install the library using:
\\\

This will install both miflora.py and ble_advertising.py modules for MiFlora sensor integration.